### PR TITLE
Not generate 'namespace' key while 'namespace' present to be 'undefined'

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-cli": "^6.7.5",
     "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-es2015": "^6.1.18",
+    "chai": "^4.2.0",
     "mocha": "^3.2.0"
   },
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,8 @@ export default function modelExtend(...models) {
     Object.assign(acc.reducers, extend.reducers);
     return acc;
   }, base);
+  
+  if (!model.namespace) delete model.namespace
 
   log(model, 'state', stateCount)
   log(model, 'subscriptions', subscriptionsCount)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert');
 const modelExtend = require('../lib').default;
+const expect = require('chai').expect;
 
 describe('modelExtend', () => {
   it('should support multi inheritance', () => {
@@ -37,6 +38,15 @@ describe('modelExtend', () => {
       },
     });
   });
+
+  it('should not generate namespace even if none namespace exists within any model', () => {
+    const res = modelExtend(
+      { state: { a: 1 } },
+      { state: { b: 2 } },
+      { state: { c: 3 } }
+    );
+    expect(res).to.not.include.keys('namespace')
+  })
 
   it('should merge states when they are objects', () => {
     const res = modelExtend({


### PR DESCRIPTION
When using umiJS, namespace will be automatically generated by framework and be filled with its file name.